### PR TITLE
Fix bug on input filenames including hyphens; add <?#...?> for one-line comments

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 Copyright © 2013 Andrey Shubin <andrey.shubin@gmail.com>
+Portions copyright © 2016 Chris White <cxwembedded@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal
@@ -18,3 +19,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 PerlPP: Perl preprocessor
 =========================
 
-Translates **Text+Perl** to **Text**.  
-It can be used for any kind of text templating, e.g. code generation.  
+Translates **Text+Perl** to **Text**.
+It can be used for any kind of text templating, e.g. code generation.
 No external modules are required, just a single file.
 
 	Usage: perl perlpp.pl [options] [filename]
@@ -15,62 +15,78 @@ No external modules are required, just a single file.
 Syntax
 ------
 
-Syntax is a bit similar to PHP.  
-Perl code has to be included between `<?` and `?>` tags.  
-There are two special modes
+Syntax is a bit similar to PHP.
+Perl code has to be included between `<?` and `?>` tags.
+There are several special modes:
 
-	<?=		echo mode, prints a Perl expression
-	<?:		command mode, executed by PerlPP itself
-	<?/		regular (code) mode with a line break appended to the previous text
+	<?=	echo mode: prints a Perl expression
+	<?:	command mode, executed by PerlPP itself
+	<?/	regular (code) mode with a line break appended to the previous text
+	<?#	comment mode: everything in <?# ... ?> is ignored.
 
-A regular mode is started with `<?` followed by any number of whitespaces or line breaks.  
-If there is any other character after `<?` then this tag will be ignored (passed as it is).  
+A regular mode is started with `<?` followed by any number of whitespaces or line breaks.
+If there is any non-whitespace character after `<?` other than those starting
+the special modes, then this tag will be ignored (passed as it is).
 
 Example
 -------
 
 	Hello <? print "world"; ?> (again).
+	<?# I don't appear in the output ?>but I do.
 	<? for ( my $i = 0; $i < 5; $i++ ) { ?>
 		number: <?= $i ?>
 	<? } ?>
 
-Result
+Result:
 
 	Hello world (again).
+	but I do.
 
+		number: 0
+
+		number: 1
+
+		number: 2
+
+		number: 3
+
+		number: 4
+
+In order to remove empty lines, one might write it like this:
+
+	Hello <? print "world"; ?> (again).
+	<?  for ( my $i = 0; $i < 5; $i++ ) { ?>number: <?= $i ?>
+	<? } ?>
+
+Result:
+
+	Hello world (again).
 	number: 0
-
 	number: 1
-
 	number: 2
-
 	number: 3
-
 	number: 4
 
-In order to remove empty lines, one might write it like this
-
-	Hello <? print "world"; ?> (again).<?
-		for ( my $i = 0; $i < 5; $i++ ) { ?>number: <?= $i ?>
-	<? } ?>
 
 Commands
 --------
 
-	<?:include file.p ?>  
+	<?:include file.p ?>
 
-or `<?:include "long file name.p" ?>` (keep a whitespace between `"` and `?>`, explained further).  
+or `<?:include "long file name.p" ?>` (keep a whitespace between `"` and `?>`, explained further).
 Includes source code of another PerlPP file into this position.
+Note that this file can be any PerlPP input, so you can also use this to
+include plain text files or other literal files.
 
-	<?:prefix foo bar ?>  
+	<?:prefix foo bar ?>
 
-Replaces word prefixes in the following output.  
+Replaces word prefixes in the following output.
 In this case words like `fooSomeWord` will become `barSomeWord`.
 
 Capturing
 ---------
 
-Sometimes it is great to get (capture) source text into a Perl string.  
+Sometimes it is great to get (capture) source text into a Perl string.
 
 	"?>		start of capturing
 	<?"		end of capturing
@@ -83,7 +99,7 @@ is the same as
 
 	<? print 'That\'s cool' . ', really.'; ?>
 
-Captured strings are properly escaped, and can be sequenced like in this example.  
+Captured strings are properly escaped, and can be sequenced like in this example.
 Moreover, they can be nested!
 
 	<?
@@ -98,7 +114,7 @@ Moreover, they can be nested!
 		<? ABC(); ?>
 	<?" ); ?>
 
-Printed characters from the second `ABC()` call are attached to the string `'alphabet '`,  
+Printed characters from the second `ABC()` call are attached to the string `'alphabet '`,
 so the result will be
 
 	abcdefghijklmnopqrstuvwxyz
@@ -110,7 +126,7 @@ Capturing works in all modes: regular, echo or command mode.
 Custom Preprocessors
 --------------------
 
-It's possible to create your own pre/post-processors with `PerlPP::AddPreprocessor` and `PerlPP::AddPostprocessor`.  
+It's possible to create your own pre/post-processors with `PerlPP::AddPreprocessor` and `PerlPP::AddPostprocessor`.
 This feature is used in [BigBenBox](https://github.com/d-ash/BigBenBox) for generating code in the C programming language.
 
 Future

--- a/perlpp.pl
+++ b/perlpp.pl
@@ -34,6 +34,7 @@ use constant OBMODE_CAPTURE	=> 1;	# same as OBMODE_PLAIN but with capturing
 use constant OBMODE_CODE	=> 2;
 use constant OBMODE_ECHO	=> 3;
 use constant OBMODE_COMMAND	=> 4;
+use constant OBMODE_COMMENT	=> 5;
 
 my $Package = '';
 my @Preprocessors = ();
@@ -165,6 +166,8 @@ sub OnOpening {
 			$insetMode = OBMODE_ECHO;
 		} elsif ( $after =~ /^:/ ) {
 			$insetMode = OBMODE_COMMAND;
+		} elsif ( $after =~ /^#/ ) {
+			$insetMode = OBMODE_COMMENT;
 		} elsif ( $after =~ /^\// ) {
 			$plain .= "\n";
 			# OBMODE_CODE
@@ -206,6 +209,8 @@ sub OnClosing {
 			print "print ${inside};\n";				# don't wrap in (), trailing semicolon
 		} elsif ( $insetMode == OBMODE_COMMAND ) {
 			ExecuteCommand( $inside );
+		} elsif ( $insetMode == OBMODE_COMMENT ) {
+			# Ignore the contents - no operation
 		} else {
 			print $inside;
 		}
@@ -339,12 +344,13 @@ sub Main {
 		} else {
 			$inputFilename = $a;
 		}
-		# TODO tranfer parameters to the processed file
+		# TODO transfer parameters to the processed file
 	}
 
 	$Package = $inputFilename;
 	$Package =~ s/^([a-zA-Z_][a-zA-Z_0-9.]*).p$/$1/;
-	$Package =~ s/[.\/\\]/_/g;
+	$Package =~ s/[^a-z0-9]/_/gi;
+		# $Package is not the whole name, so can start with a number.
 
 	StartOB();
 	print "package PPP_${Package};\nuse strict;\nuse warnings;\nmy %DEF = ();\n${argEval}\n";
@@ -360,3 +366,4 @@ sub Main {
 }
 
 Main( @ARGV );
+


### PR DESCRIPTION
Great tool!  I found two issues that this PR fixes, as far as I can tell from my limited testing.

 1. Input filenames including hyphens would fail because the resulting `$Package` included a hyphen.  This PR squashes `[^a-zA-Z0-9]` down to `_`.

 1. Comments had to be terminated by a newline, so

        <? #  this is a comment
        ?>

    would work, but

        <? #  this is a comment ?>

    would not.  This PR adds `<?# comment without trailing \n! ?>` for comments, whether single or multi-line.
