### PR TITLE
Added <?!...?> (external cmd) and -k (keep going)

### DIFF
--- a/t/cmdline.t
+++ b/t/cmdline.t
@@ -2,7 +2,7 @@
 # Tests of perlpp command-line options
 use strict;
 use warnings;
-use Test::More 'no_plan';
+use Test::More;
 use IPC::Run3;
 use constant CMD => 'perl perlpp.pl';
 
@@ -96,9 +96,17 @@ my @testcases=(
 
 ); #@testcases
 
-#plan tests => scalar @testcases;
-# TODO count the out_re and err_re in @testcases, since the number of
+# count the out_re and err_re in @testcases, since the number of
 # tests is the sum of those counts.
+my $testcount = 0;
+
+for my $lrTest (@testcases) {
+	my ($out_re, $err_re) = @$lrTest[2..3];
+	++$testcount if defined $out_re;
+	++$testcount if defined $err_re;
+}
+
+plan tests => $testcount;
 
 for my $lrTest (@testcases) {
 	my ($opts, $testin, $out_re, $err_re) = @$lrTest;

--- a/t/external-command.t
+++ b/t/external-command.t
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl -W
+# Tests of perlpp <?!...?> external commands
+use strict;
+use warnings;
+use Test::More;
+use IPC::Run3;
+use constant CMD => 'perl perlpp.pl';
+
+(my $whereami = __FILE__) =~ s/macro\.t$//;
+my $incfn = '\"' . $whereami . 'included.txt\"';
+	# escape the quotes for the shell
+
+my @testcases=(
+	# [$cmdline_options, $in (the script), $out_re (expected output),
+	#	$err_re (stderr output, if any)].
+	# Specify undef for $out_re or $err_re to skip it.
+
+	['', '<?! false ?> More stuff', qr{^$} , qr{command 'false' failed: process exited}],
+	['-k', '<?! false ?> More stuff', qr{^ More stuff$} , qr{command 'false' failed: process exited}],
+	# Using capturing for part of the command
+	['', '<?!echo -n "?>Hello!?<?"?>', qr{^Hello!\?$}],
+
+); #@testcases
+
+# count the out_re and err_re in @testcases, since the number of
+# tests is the sum of those counts.
+my $testcount = 0;
+
+for my $lrTest (@testcases) {
+	my ($out_re, $err_re) = @$lrTest[2..3];
+	++$testcount if defined $out_re;
+	++$testcount if defined $err_re;
+}
+
+plan tests => $testcount;
+
+for my $lrTest (@testcases) {
+	my ($opts, $testin, $out_re, $err_re) = @$lrTest;
+
+	my ($out, $err);
+	print STDERR CMD . " $opts", " <<<'", $testin, "'\n";
+	run3 CMD . " $opts", \$testin, \$out, \$err;
+
+	if(defined $out_re) {
+		like($out, $out_re);
+	}
+	if(defined $err_re) {
+		like($err, $err_re);
+	}
+	#print STDERR "$err\n";
+
+} # foreach test
+
+# TODO test -o / --output, and processing input from files rather than stdin
+
+# vi: set ts=4 sts=0 sw=4 noet ai: #
+

--- a/t/readme.t
+++ b/t/readme.t
@@ -55,6 +55,8 @@ RESULT
 	],
 	['foo<? print "bar";?>',"foobar"],
 	['foo<?/ print "bar";?>',"foo\nbar"],
+	['<?!echo Howdy!?>',"Howdy!\n"],
+	# Note: tests of -k are in t/external-command.t
 	['foo<?:prefix foo bar ?>' . "\n" . 'foo fooSomeWord thingfoo',
 		"foo\nbar barSomeWord thingfoo"],
 	['<? print "?>That\'s cool<?" . "?>, really.<?"; ?>',


### PR DESCRIPTION
On Cygwin, I was able to run external commands using 

    <?= `echo foo` ?>

However, when I did so, the exit code of the child process was ignored.  I ran into situations in which a child process failed silently and I didn't know about it.

This adds a new external-command mode `<?! echo foo ?>`.  The effect is the same as the above - whatever the external command prints to stdout is rolled into the generated script verbatim.  However, perlpp will return an error exit code if the given command fails.

In case you want the old behaviour, you can still use backticks with `<?=`.  Alternatively, you can use the new `-k` (`--keep-going`) switch.  With `-k`, an error message will still be printed to STDERR, but script execution will keep going.