### PR TITLE
Rework tests to run more cleanly in a sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /tags
 /fatlib
 /stuff
+*.stackdump
+core
 
 # Dist
 /Text-PerlPP*

--- a/MANIFEST
+++ b/MANIFEST
@@ -9,9 +9,10 @@ pack.PL				Script to make the packed version
 README
 README.md			The tutorial
 t/00-load.t
-t/01-basic.t
-t/01-readme.t
-t/02-cmdline.t
+t/01-capture.t
+t/02-basic.t
+t/02-readme.t
+t/03-cmdline.t
 t/03-idempotency.t
 t/04-include.t
 t/05-external-command.t
@@ -21,5 +22,7 @@ t/a.txt
 t/b.txt
 t/c.txt
 t/included.txt
+t/lib/PerlPPTest.pm		The test kit
+t/lib/TestcaseList.pm		Helper library for autonumbering testcases
 t/multiline.txt
 t/unclosed.txt

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -75,6 +75,4 @@
 # Skip some specific files
 ^Makefile-premodule
 ^tags
-
-# Things we're still working on
-^t\/lib
+\.stackdump$

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,12 +4,21 @@ use warnings;
 use ExtUtils::MakeMaker;
 use Config;
 
-# Get the filename of the Perl interpreter running this.  From perlvar.
-my $secure_perl_path = $Config{perlpath};
-if ($^O ne 'VMS') {
-    $secure_perl_path .= $Config{_exe}
-        unless $secure_perl_path =~ m/$Config{_exe}$/i;
-}
+# Get the filename of the Perl interpreter running this.  Modified from perlvar.
+# The -x test is for cygwin or other systems where $Config{perlpath} has no
+# extension and $Config{_exe} is nonempty.  E.g., symlink perl->perl5.10.1.exe.
+# There is no "perl.exe" on such a system.
+sub get_perl_filename {
+    my $secure_perl_path = $Config{perlpath};
+    if ($^O ne 'VMS') {
+        $secure_perl_path .= $Config{_exe}
+            unless (-x $secure_perl_path) ||
+                            ($secure_perl_path =~ m/$Config{_exe}$/i);
+    }
+    return $secure_perl_path;
+} # get_perl_filename()
+
+my $secure_perl_path = get_perl_filename();
 
 sub MY::postamble {     # TODO also handle Windows nmake syntax (SET vs. export)
     return <<EOT;
@@ -17,12 +26,14 @@ authortest:
 \tRELEASE_TESTING=1 prove -l xt"
 
 testhere:   # Run the tests from lib rather than blib
-\tperl -Ilib -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
+\t"$secure_perl_path" -Ilib -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
 
-testpacked: pack    # Test the packed version
+testpacked: pack    # Test the packed version.
 \tPERLPP_NOUSE=1 PERLPP_PERLOPTS="blib/perlpp" \\
-\tperl -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
+\t"$secure_perl_path" -Ilib -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
 EOT
+    # Note: testpacked uses -Ilib so that I don't have to conditionally
+    # use Text::PerlPP in t/lib/PerlPPTest.pm.
 } #postamble
 
 WriteMakefile(
@@ -39,15 +50,15 @@ WriteMakefile(
     },
     BUILD_REQUIRES => {
         'App::FatPacker' => '0',
-        'IPC::Run3' => '0',
-        'Test::More' => '0',
     },
     TEST_REQUIRES => {
         'Capture::Tiny' => '0',
         'Carp' => '0',
         'Config' => '0',
         'File::Spec' => '0',
+        'IPC::Run3' => '0',
         'rlib' => '0',
+        'Test::More' => '0',
         'Text::ParseWords' => '0',
         'Text::Diff' => '0',   # for t/03-idempotency.t
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,11 +17,10 @@ authortest:
 \tRELEASE_TESTING=1 prove -l xt"
 
 testhere:   # Run the tests from lib rather than blib
-\texport PERLPP_CMD="\\\"$secure_perl_path\\\" -Ilib bin/perlpp"; \\
 \tperl -Ilib -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
 
 testpacked: pack    # Test the packed version
-\texport PERLPP_NOUSE=1 PERLPP_PERLOPTS="blib/perlpp"; \\
+\tPERLPP_NOUSE=1 PERLPP_PERLOPTS="blib/perlpp" \\
 \tperl -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
 EOT
 } #postamble

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,7 +43,14 @@ WriteMakefile(
         'IPC::Run3' => '0',
         'Test::More' => '0',
     },
-    # TODO add TEST_REQUIRES
+    TEST_REQUIRES => {
+        'Capture::Tiny' => '0',
+        'Carp' => '0',
+        'Config' => '0',
+        'File::Spec' => '0',
+        'Text::ParseWords' => '0',
+        'Text::WordDiff' => '0',
+    },
     PREREQ_PM => {
         'Getopt::Long'     => '2.5',    # Per issue #17
         'Pod::Usage'       => '0',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,7 @@ testhere:   # Run the tests from lib rather than blib
 \tperl -Ilib -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
 
 testpacked: pack    # Test the packed version
-\texport PERLPP_NOUSE=1 PERLPP_CMD="\\\"$secure_perl_path\\\" blib/perlpp"; \\
+\texport PERLPP_NOUSE=1 PERLPP_PERLOPTS="blib/perlpp"; \\
 \tperl -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
 EOT
 } #postamble

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -48,7 +48,7 @@ WriteMakefile(
         'Config' => '0',
         'File::Spec' => '0',
         'Text::ParseWords' => '0',
-        'Text::WordDiff' => '0',
+        'Text::Diff' => '0',   # for t/03-idempotency.t
     },
     PREREQ_PM => {
         'Getopt::Long'     => '2.5',    # Per issue #17

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,6 +47,7 @@ WriteMakefile(
         'Carp' => '0',
         'Config' => '0',
         'File::Spec' => '0',
+        'rlib' => '0',
         'Text::ParseWords' => '0',
         'Text::Diff' => '0',   # for t/03-idempotency.t
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,18 +2,26 @@ use 5.010;
 use strict;
 use warnings;
 use ExtUtils::MakeMaker;
+use Config;
 
-sub MY::postamble {
+# Get the filename of the Perl interpreter running this.  From perlvar.
+my $secure_perl_path = $Config{perlpath};
+if ($^O ne 'VMS') {
+    $secure_perl_path .= $Config{_exe}
+        unless $secure_perl_path =~ m/$Config{_exe}$/i;
+}
+
+sub MY::postamble {     # TODO also handle Windows nmake syntax (SET vs. export)
     return <<EOT;
 authortest:
 \tRELEASE_TESTING=1 prove -l xt"
 
 testhere:   # Run the tests from lib rather than blib
-\texport PERLPP_CMD="perl -Ilib bin/perlpp"; \\
+\texport PERLPP_CMD="\\\"$secure_perl_path\\\" -Ilib bin/perlpp"; \\
 \tperl -Ilib -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
 
 testpacked: pack    # Test the packed version
-\texport PERLPP_NOUSE=1 PERLPP_CMD="perl blib/perlpp"; \\
+\texport PERLPP_NOUSE=1 PERLPP_CMD="\\\"$secure_perl_path\\\" blib/perlpp"; \\
 \tperl -e 'use Test::Harness "runtests"; runtests \@ARGV;' -- t/*.t
 EOT
 } #postamble
@@ -35,6 +43,7 @@ WriteMakefile(
         'IPC::Run3' => '0',
         'Test::More' => '0',
     },
+    # TODO add TEST_REQUIRES
     PREREQ_PM => {
         'Getopt::Long'     => '2.5',    # Per issue #17
         'Pod::Usage'       => '0',

--- a/bin/perlpp
+++ b/bin/perlpp
@@ -2,7 +2,7 @@
 # To run this manually from the source tree, do
 #     perl -Ilib bin/perlpp
 use strict; use warnings; use Text::PerlPP;
-exit(Text::PerlPP::Main(\@ARGV));
+exit(Text::PerlPP->new->Main(\@ARGV));
 __END__
 # ### Documentation #######################################################
 

--- a/lib/Text/PerlPP.pm
+++ b/lib/Text/PerlPP.pm
@@ -3,7 +3,7 @@
 
 package Text::PerlPP;
 
-our $VERSION = '0.4.0';
+our $VERSION = '0.500001';
 
 use 5.010001;
 use strict;
@@ -736,7 +736,7 @@ sub _parse_command_line {
 	}
 
 	# Process other arguments.  TODO? support multiple input filenames?
-	$hrOptsOut->{INPUT_FILENAME} = $ARGV[0] // "";
+	$hrOptsOut->{INPUT_FILENAME} = $lrArgs->[0] // "";
 
 	return true;	# Go ahead and run
 } #_parse_command_line()

--- a/lib/Text/PerlPP.pm
+++ b/lib/Text/PerlPP.pm
@@ -255,8 +255,10 @@ sub ExecuteCommand {
 			};
 		};
 
-		print "Macro code run:\n$code\n" =~ s/^/#/gmr
-			if($self->{Opts}->{DEBUG});
+		if($self->{Opts}->{DEBUG}) {
+			(my $c = $code) =~ s/^/#/gm;
+			emit "Macro code run:\n$c\n"
+		}
 		eval $code;
 		my $err = $@; chomp $err;
 		emit 'print ' . $self->PrepareString( $self->EndOB() ) . ";\n";
@@ -279,8 +281,10 @@ sub ExecuteCommand {
 				$1
 			};
 		};
-		print "Immediate code run:\n$code\n" =~ s/^/#/gmr
-			if($self->{Opts}->{DEBUG});
+		if($self->{Opts}->{DEBUG}) {
+			(my $c = $code) =~ s/^/#/gm;
+			emit "Immediate code run:\n$c\n"
+		}
 		eval( $code );
 		my $err = $@; chomp $err;
 
@@ -792,16 +796,11 @@ sub _parse_command_line {
 
 sub Main {
 	my $self = shift or die("Please use Text::PerlPP->new()->Main");
-
 	my $lrArgv = shift // [];
-	#say STDERR "\n## -----------------\n## argv:\n",
-	#	(Dumper($lrArgv) =~ s/^/## /mgr);
-	#say STDERR "self ", Dumper($self);
+
 	unless(_parse_command_line( $lrArgv, $self->{Opts} )) {
 		return EXIT_OK;		# TODO report param err vs. proc err?
 	}
-
-	#say STDERR "## opts:\n", (Dumper($self->{Opts}) =~ s/^/## /mgr);
 
 	if($self->{Opts}->{PRINT_VERSION}) {
 		print "PerlPP version $Text::PerlPP::VERSION\n";
@@ -892,9 +891,6 @@ sub Main {
 				}
 			keys %{$self->{Opts}->{SETS}};
 
-	#say STDERR "\n# Defs_RE: $self->{Defs_RE}";
-	#say STDERR "# Defs_repl_text:\n", (Dumper($self->{Defs_repl_text})=~s/^/# /gmr);
-	#say STDERR "# Sets\n", (Dumper($self->{Sets})=~s/^/# /gmr);
 	# Make the copy for runtime
 	emit "my %S = (\n";
 	for my $defname (keys %{$self->{Opts}->{SETS}}) {

--- a/lib/Text/PerlPP.pm
+++ b/lib/Text/PerlPP.pm
@@ -248,8 +248,10 @@ sub ExecuteCommand {
 		# 	to with its full package name if we didn't have the `our`.
 		# TODO add a pound line to this eval based on the current line number
 
+		# NOTE: `package NAME BLOCK` syntax was added in Perl 5.14.0, May 2011.
 		my $code = qq{ ;
-			package $self->{Package} {
+			{
+				package $self->{Package};
 				our \$@{[PPP_SELF_INSIDE]};
 				$1
 			};
@@ -276,7 +278,8 @@ sub ExecuteCommand {
 
 		# TODO add a pound line to this eval
 		my $code = qq{ ;
-			package $self->{Package} {
+			{
+				package $self->{Package};
 				our \$@{[PPP_SELF_INSIDE]};
 				$1
 			};

--- a/lib/Text/PerlPP.pm
+++ b/lib/Text/PerlPP.pm
@@ -3,6 +3,8 @@
 
 package Text::PerlPP;
 
+# Semantic versioning, packed per Perl rules.  Must always be at least one
+# digit left of the decimal, and six digits right of the decimal.
 our $VERSION = '0.500001';
 
 use 5.010001;
@@ -805,8 +807,9 @@ sub Main {
 		return EXIT_OK;		# TODO report param err vs. proc err?
 	}
 
-	if($self->{Opts}->{PRINT_VERSION}) {
-		print "PerlPP version $Text::PerlPP::VERSION\n";
+	if($self->{Opts}->{PRINT_VERSION}) {	# print version, raw and dotted
+		$Text::PerlPP::VERSION =~ m<^([^\.]+)\.(\d{3})(\d{3})>;
+		printf "PerlPP version %d.%d.%d ($VERSION)\n", $1, $2, $3;
 		if($self->{Opts}->{PRINT_VERSION} > 1) {
 			print "Script: $0\nText::PerlPP: $INC{'Text/PerlPP.pm'}\n";
 		}

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -3,16 +3,27 @@ use 5.010;
 use strict;
 use warnings;
 use Test::More;
+use rlib './lib';
 
 BEGIN {
-	if($ENV{PERLPP_NOUSE} || 0) {
-		plan skip_all => 'Loading not tested in this configuration (PERLPP_NOUSE)';
-	} else {
-		plan tests => 1;
-		use_ok( 'Text::PerlPP' ) || print "Bail out!\n";
-		diag("Included from $INC{'Text/PerlPP.pm'}");
-	}
-}
+    if($ENV{PERLPP_NOUSE} || 0) {
+        plan skip_all => 'Loading not tested in this configuration (PERLPP_NOUSE)';
+    } else {
+        plan tests => 2;
+        unless(use_ok( 'Text::PerlPP' )) {
+            diag("@INC is:\n  ", join("\n  ", @INC), "\n");
+            BAIL_OUT("Cannot load Text::PerlPP");
+        };
+
+        unless(use_ok( 'PerlPPTest' )) {
+            diag("@INC is:\n  ", join("\n  ", @INC), "\n");
+            BAIL_OUT("Cannot load PerlPPTest");
+        };
+        diag("Running as $0");
+        diag("Text::PerlPP included from $INC{'Text/PerlPP.pm'}");
+        diag("PerlPPTest included from $INC{'PerlPPTest.pm'}");
+    }
+} # BEGIN
 
 done_testing();
 # vi: set ts=4 sts=4 sw=4 et ai: #

--- a/t/01-capture.t
+++ b/t/01-capture.t
@@ -1,0 +1,16 @@
+#!perl
+# Some basic tests for perlpp
+use rlib './lib';
+use PerlPPTest;
+
+my ($stdout, $stderr, @result);
+($stdout, $stderr, @result) = capture {
+    local *STDIN;
+    close STDIN;
+    Text::PerlPP::Main(['-e','say 42;']);
+};
+
+is($stdout, "42\n");
+
+done_testing();
+# vi: set ts=4 sts=4 sw=4 et ai: #

--- a/t/01-capture.t
+++ b/t/01-capture.t
@@ -2,6 +2,7 @@
 # Some basic tests for perlpp
 use rlib './lib';
 use PerlPPTest;
+plan tests => 1;
 
 my ($stdout, $stderr, @result);
 ($stdout, $stderr, @result) = capture {

--- a/t/01-capture.t
+++ b/t/01-capture.t
@@ -2,16 +2,20 @@
 # Some basic tests for perlpp
 use rlib './lib';
 use PerlPPTest;
-plan tests => 1;
 
-my ($stdout, $stderr, @result);
-($stdout, $stderr, @result) = capture {
-    local *STDIN;
-    close STDIN;
-    Text::PerlPP->new->Main(['-e','say 42;']);
-};
+if($ENV{PERLPP_NOUSE} || 0) {
+    plan skip_all => 'Loading not tested in this configuration (PERLPP_NOUSE)';
 
-is($stdout, "42\n");
+} else {
+    plan tests => 1;
+    my ($stdout, $stderr, @result) = capture {
+        local *STDIN;
+        close STDIN;
+        Text::PerlPP->new->Main(['-e','say 42;']);
+    };
+
+    is($stdout, "42\n");
+}
 
 done_testing();
 # vi: set ts=4 sts=4 sw=4 et ai: #

--- a/t/01-capture.t
+++ b/t/01-capture.t
@@ -7,7 +7,7 @@ my ($stdout, $stderr, @result);
 ($stdout, $stderr, @result) = capture {
     local *STDIN;
     close STDIN;
-    Text::PerlPP::Main(['-e','say 42;']);
+    Text::PerlPP->new->Main(['-e','say 42;']);
 };
 
 is($stdout, "42\n");

--- a/t/02-basic.t
+++ b/t/02-basic.t
@@ -4,9 +4,6 @@ use rlib './lib';
 use PerlPPTest;
 
 use IPC::Run3;
-#use constant CMD => ($ENV{PERLPP_CMD} || "$^X -Iblib/lib blib/script/perlpp");
-#	# TODO use $^X even if a PERLPP_CMD is provided.
-#diag "perlpp command: " . CMD;
 (my $whereami = __FILE__) =~ s/02-basic\.t$//;
 #diag join(' ', 'File is', __FILE__, 'whereami', $whereami);
 

--- a/t/02-basic.t
+++ b/t/02-basic.t
@@ -8,7 +8,7 @@ use IPC::Run3;
 #	# TODO use $^X even if a PERLPP_CMD is provided.
 #diag "perlpp command: " . CMD;
 (my $whereami = __FILE__) =~ s/02-basic\.t$//;
-diag join(' ', 'File is' . __FILE__, 'whereami', $whereami);
+#diag join(' ', 'File is', __FILE__, 'whereami', $whereami);
 
 my @testcases=(
 	# [$in (the script), $out (expected output), $err (stderr output, if any)]

--- a/t/02-basic.t
+++ b/t/02-basic.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -W
+#!/usr/bin/env perl
 # Some basic tests for perlpp
 use rlib './lib';
 use PerlPPTest;
@@ -42,7 +42,7 @@ my @testcases=(
 
 ); #@testcases
 
-plan tests => scalar @testcases;
+plan tests => count_tests(\@testcases, 1, 2);
 
 for my $lrTest (@testcases) {
 	my ($testin, $refout, $referr) = @$lrTest;

--- a/t/02-basic.t
+++ b/t/02-basic.t
@@ -1,14 +1,14 @@
 #!/usr/bin/env perl -W
 # Some basic tests for perlpp
-use strict;
-use warnings;
-use Test::More;
-use IPC::Run3;
-use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
-diag "perlpp command: " . CMD;
-(my $whereami = __FILE__) =~ s/01-basic\.t$//;
+use rlib './lib';
+use PerlPPTest;
 
-my ($in, $out, $err);
+use IPC::Run3;
+#use constant CMD => ($ENV{PERLPP_CMD} || "$^X -Iblib/lib blib/script/perlpp");
+#	# TODO use $^X even if a PERLPP_CMD is provided.
+#diag "perlpp command: " . CMD;
+(my $whereami = __FILE__) =~ s/02-basic\.t$//;
+diag join(' ', 'File is' . __FILE__, 'whereami', $whereami);
 
 my @testcases=(
 	# [$in (the script), $out (expected output), $err (stderr output, if any)]
@@ -46,10 +46,14 @@ plan tests => scalar @testcases;
 
 for my $lrTest (@testcases) {
 	my ($testin, $refout, $referr) = @$lrTest;
-	run3 CMD, \$testin, \$out, \$err;
+
+	my ($in, $out, $err);
+	run_perlpp [], \$testin, \$out, \$err;
+
 	if(defined $refout) {
 		is($out, $refout);
 	}
+
 	if(defined $referr) {
 		is($err, $referr);
 	}

--- a/t/02-readme.t
+++ b/t/02-readme.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -W
+#!/usr/bin/env perl
 # Tests from perlpp's README.md and bin/perlpp's POD.
 use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 use rlib './lib';
@@ -89,7 +89,7 @@ RESULT
 	[ '<?= "!" . "?>foo<?= 42 ?><?" . "bar" ?>', '!foo42bar' ],
 ); #@testcases
 
-plan tests => scalar @testcases;
+plan tests => count_tests(\@testcases, 1, 2);
 
 for my $lrTest (@testcases) {
 	my ($testin, $refout, $referr) = @$lrTest;

--- a/t/02-readme.t
+++ b/t/02-readme.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 # Tests from perlpp's README.md and bin/perlpp's POD.
-use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 use rlib './lib';
 use PerlPPTest;
 
@@ -95,7 +94,6 @@ for my $lrTest (@testcases) {
 	my ($testin, $refout, $referr) = @$lrTest;
 	my ($in, $out, $err);
 
-	#run3 CMD, \$testin, \$out, \$err;
 	run_perlpp [], \$testin, \$out, \$err;
 
 	if(defined $refout) {

--- a/t/02-readme.t
+++ b/t/02-readme.t
@@ -1,10 +1,8 @@
 #!/usr/bin/env perl -W
 # Tests from perlpp's README.md and bin/perlpp's POD.
-use strict;
-use warnings;
-use Test::More;
-use IPC::Run3;
 use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
+use rlib './lib';
+use PerlPPTest;
 
 my ($in, $out, $err);
 

--- a/t/02-readme.t
+++ b/t/02-readme.t
@@ -4,8 +4,6 @@ use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 use rlib './lib';
 use PerlPPTest;
 
-my ($in, $out, $err);
-
 my @testcases=(		# In the order they are given in README.md
 	# [$in, $out, $err (if any)]
 
@@ -95,7 +93,11 @@ plan tests => scalar @testcases;
 
 for my $lrTest (@testcases) {
 	my ($testin, $refout, $referr) = @$lrTest;
-	run3 CMD, \$testin, \$out, \$err;
+	my ($in, $out, $err);
+
+	#run3 CMD, \$testin, \$out, \$err;
+	run_perlpp [], \$testin, \$out, \$err;
+
 	if(defined $refout) {
 		is($out, $refout);
 	}

--- a/t/03-cmdline.t
+++ b/t/03-cmdline.t
@@ -73,7 +73,7 @@ my @testcases=(
 		qr/^_foo bar foobar barfoo$/ ),
 
 	# Sets, which do not textually substitute
-	do{L('-E -sfoo=42','<? my $foo; ?>foo',qr/^foo$/ )},
+	do{L('-sfoo=42','<? my $foo; ?>foo',qr/^foo$/ )},
 	do{L('-sfoo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ )},
 	[__LINE__, '--set foo=42','<? my $foo; ?>foo',qr/^foo$/ ],
 	do{L('--set foo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ )},
@@ -124,8 +124,8 @@ for my $lrTest (@testcases) {
 	my ($where, $opts, $testin, $out_re, $err_re) = @$lrTest;
 
 	my ($out, $err);
-	diag '=' x 70;
-	diag $opts, " <<<'", $testin, "'\n";
+	#diag '=' x 70;
+	#diag $opts, " <<<'", $testin, "'\n";
 	run_perlpp $opts, \$testin, \$out, \$err;
 	#diag "Done running";
 
@@ -137,7 +137,7 @@ for my $lrTest (@testcases) {
 		#diag "checking stderr";
 		like($err, $err_re, "stderr $where");
 	}
-	print STDERR "$err\n";
+	#print STDERR "$err\n";
 
 } # foreach test
 

--- a/t/03-cmdline.t
+++ b/t/03-cmdline.t
@@ -1,115 +1,109 @@
 #!/usr/bin/env perl
 # Tests of perlpp command-line options
-use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 use rlib './lib';
 use PerlPPTest;
+use TestcaseList;
 
-# Note: for all the L() calls, without a do{} around them, the line number
-# from caller() is the line number where `my @testcases` occurs.
-# TODO find out if there's a better way than do{L()}.  Maybe an L that
-# takes a block that returns a list?  That might or might not work ---
-# syntactically,
-# 	perl -MData::Dumper -E 'sub L :prototype(&) { my $func=shift; my @x = &$func(); say Dumper(\@x); }; L{1,2}'
-# does work, but I don't know if it would have the right caller.
+# Testcase format:
+# [scalar filename/lineno (added by the TestcaseList code),
+# 	$cmdline_options, $in (the script), $out_re (expected output),
+#	$err_re (stderr output, if any)]
 
-my @testcases=(
-	# [scalar filename/lineno (added by L()),
-	# 	$cmdline_options, $in (the script), $out_re (expected output),
-	#	$err_re (stderr output, if any)]
+# TODO add skip() to TestcaseList loader --- otherwise the line numbers
+# will be off here.
 
+my $testcases = TestcaseList->new(__LINE__);
 	# version
-	do{L('-v','',qr/\bversion\b/) },
-	do{L('--version','',qr/\bversion\b/)},
+$testcases->load('-v','',qr/\bversion\b/)->
+	('--version','',qr/\bversion\b/)
 
 	# Debug output
-	L('-d','',qr/^package PPP_[0-9]*;/m),
-	L('-d', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}),
-	L('--debug', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}),
-	L('-E', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}),
+	('-d','',qr/^package PPP_[0-9]*;/m)
+	('-d', '<?= 2+2 ?>', qr{print\s+2\+2\s*;})
+	('--debug', '<?= 2+2 ?>', qr{print\s+2\+2\s*;})
+	('-E', '<?= 2+2 ?>', qr{print\s+2\+2\s*;})
 
 	# Usage
-	L('-h --z_noexit_on_help', '', qr/^Usage/),
-	L('--help --z_noexit_on_help', '', qr/^Usage/),
+	('-h --z_noexit_on_help', '', qr/^Usage/)
+	('--help --z_noexit_on_help', '', qr/^Usage/)
 
 	# Eval at start of file
-	L('-e \'my $foo=42;\'', '<?= $foo ?>', qr/^42$/),
-	L('--eval \'my $foo=42;\'','<?= $foo ?>', qr/^42$/),
-	L('-d -e \'my $foo=42;\'','<?= $foo ?>', qr/^my \$foo=42;/m),
-	L('--debug --eval \'my $foo=42;\'','<?= $foo ?>', qr/^print\s+\$foo\s*;/m),
+	(['-e', q(my $foo=42;)], '<?= $foo ?>', qr/^42$/)
+	(['--eval', q(my $foo=42;)],'<?= $foo ?>', qr/^42$/)
+	(['-d','-e', q(my $foo=42;)],'<?= $foo ?>', qr/^my \$foo=42;/m)
+	(['--debug','--eval', q(my $foo=42;)],'<?= $foo ?>', qr/^print\s+\$foo\s*;/m)
 
 	# Definitions: name formats
-	L('-Dfoo', '<? print "yes" if $D{foo}; ?>',qr/^yes$/),
-	L('-Dfoo42', '<? print "yes" if $D{foo42}; ?>',qr/^yes$/),
-	L('-Dfoo_42', '<? print "yes" if $D{foo_42}; ?>',qr/^yes$/),
-	L('-D_x', '<? print "yes" if $D{_x}; ?>',qr/^yes$/),
-	L('-D_1', '<? print "yes" if $D{_1}; ?>',qr/^yes$/),
+	('-Dfoo', '<? print "yes" if $D{foo}; ?>',qr/^yes$/)
+	('-Dfoo42', '<? print "yes" if $D{foo42}; ?>',qr/^yes$/)
+	('-Dfoo_42', '<? print "yes" if $D{foo_42}; ?>',qr/^yes$/)
+	('-D_x', '<? print "yes" if $D{_x}; ?>',qr/^yes$/)
+	('-D_1', '<? print "yes" if $D{_1}; ?>',qr/^yes$/)
 
 	# Definitions with --define
-	L('--define foo', '<? print "yes" if $D{foo}; ?>',qr/^yes$/),
-	L('--define foo=42 --define bar=127', '<?= $D{foo} * $D{bar} ?>',qr/^5334$/),
+	('--define foo', '<? print "yes" if $D{foo}; ?>',qr/^yes$/)
+	('--define foo=42 --define bar=127', '<?= $D{foo} * $D{bar} ?>',qr/^5334$/)
 
 	# Definitions: :define/:undef
-	L('','<?:define foo?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^yes$/),
-	L('','<?:define foo 42?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^yes$/),
-	L('','<?:define foo 42?><?= $D{foo} ?>',qr/^42$/),
-	L('','<?:define foo "a" . "b" ?><?= $D{foo} ?>',qr/^ab$/),
-	L('-Dfoo','<?:undef foo?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^no$/),
+	('','<?:define foo?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^yes$/)
+	('','<?:define foo 42?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^yes$/)
+	('','<?:define foo 42?><?= $D{foo} ?>',qr/^42$/)
+	('','<?:define foo "a" . "b" ?><?= $D{foo} ?>',qr/^ab$/)
+	('-Dfoo','<?:undef foo?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^no$/)
 
 	# Definitions: values
-	L('-Dfoo=41025.5', '<?= $D{foo} ?>',qr/^41025.5$/),
-	L('-D foo=2017', '<?= $D{foo} ?>',qr/^2017$/),
-	L('-D foo=\"blah\"', '<?= $D{foo} ?>',qr/^blah$/),
+	('-Dfoo=41025.5', '<?= $D{foo} ?>',qr/^41025.5$/)
+	('-D foo=2017', '<?= $D{foo} ?>',qr/^2017$/)
+	([qw(-D foo="blah")], '<?= $D{foo} ?>',qr/^blah$/)
 		# Have to escape the double-quotes so perl sees it as a string
 		# literal instead of a bareword.
-	L('-D foo=42 -D bar=127', '<?= $D{foo} * $D{bar} ?>',qr/^5334$/),
-	L('', '<? $D{x}="%D always exists even if empty"; ?><?= $D{x} ?>',
-		qr/^%D always exists even if empty$/),
+	('-D foo=42 -D bar=127', '<?= $D{foo} * $D{bar} ?>',qr/^5334$/)
+	('', '<? $D{x}="%D always exists even if empty"; ?><?= $D{x} ?>', qr/^%D always exists even if empty$/)
 
 	# Textual substitution
-	L('-Dfoo=42','<? my $foo; ?>foo',qr/^42$/ ),
-	L('-Dfoo=\'"a phrase"\'','<? my $foo; ?>foo',qr/^a phrase$/ ),
-	L('-Dfoo=\"bar\"','_foo foo foobar barfoo',qr/^_foo bar foobar barfoo$/ ),
-	L('-Dfoo=\"bar\" --define barfoo','_foo foo foobar barfoo',
-		qr/^_foo bar foobar barfoo$/ ),
+	('-Dfoo=42','<? my $foo; ?>foo',qr/^42$/ )
+	([q(-Dfoo="a phrase")],'<? my $foo; ?>foo',qr/^a phrase$/ )
+	(['-Dfoo="bar"'], '_foo foo foobar barfoo 1',qr/^_foo bar foobar barfoo 1$/ )
+	(['-Dfoo="bar"', '--define', 'barfoo'], '_foo foo foobar barfoo 2', qr/^_foo bar foobar barfoo 2$/ )
 
 	# Sets, which do not textually substitute
-	do{L('-sfoo=42','<? my $foo; ?>foo',qr/^foo$/ )},
-	do{L('-sfoo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ )},
-	[__LINE__, '--set foo=42','<? my $foo; ?>foo',qr/^foo$/ ],
-	do{L('--set foo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ )},
+	('-sfoo=42','<? my $foo; ?>foo',qr/^foo$/ )
+	('-sfoo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ )
+	('--set foo=42','<? my $foo; ?>foo',qr/^foo$/ )
+	('--set foo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ )
 
 	# Conditionals
-	L('-Dfoo=42','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
-	L('-Dfoo=2','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^yes$/ ),
-	L('-Dfoo','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
-	L('-Dfoo','<?:if foo==1?>yes<?:else?>no<?:endif?>',qr/^yes$/ ),
+	('-Dfoo=42','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ )
+	('-Dfoo=2','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^yes$/ )
+	('-Dfoo','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ )
+	('-Dfoo','<?:if foo==1?>yes<?:else?>no<?:endif?>',qr/^yes$/ )
 		# The default value is true, which compares equal to 1.
-	L('-Dfoo','<?:if foo?>yes<?:else?>no<?:endif?>',qr/^yes$/ ),
-	L('','<?:if foo?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
-	L('','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
+	('-Dfoo','<?:if foo?>yes<?:else?>no<?:endif?>',qr/^yes$/ )
+	('','<?:if foo?>yes<?:else?>no<?:endif?>',qr/^no$/ )
+	('','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ )
 		# For consistency, all :if tests evaluate to false if the
 		# named variable is not defined.
 
 	# Undefining
-	L('-Dfoo','<?:undef foo?><?:if foo?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
+	('-Dfoo','<?:undef foo?><?:if foo?>yes<?:else?>no<?:endif?>',qr/^no$/ )
 	#
 	# Three forms of elsif
-	L('', '<?:if foo eq "1" ?>yes<?:elif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/),
-	L('', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/),
-	L('', '<?:if foo eq "1" ?>yes<?:elseif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/),
+	('', '<?:if foo eq "1" ?>yes<?:elif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/)
+	('', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/)
+	('', '<?:if foo eq "1" ?>yes<?:elseif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/)
 
 	# elsif with definitions
-	L('-Dfoo', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^yes$/),
-	L('-Dfoo=1', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^yes$/),
+	('-Dfoo', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^yes$/)
+	('-Dfoo=1', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^yes$/)
 		# Automatic conversion of numeric 1 to string in "eq" context
-	L('-Dfoo=\\"x\\"', '<?= $D{foo} . "\n" ?><?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^x\nmaybe$/),
-	L('-Dfoo=\\"y\\"', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/),
+	(['-Dfoo="x"'], '<?= $D{foo} . "\n" ?><?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^x\nmaybe$/)
+	(['-Dfoo="y"'], '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/)
 
-); #@testcases
+; #$testcases
 
-plan tests => count_tests(\@testcases, 3, 4);
+plan tests => count_tests($testcases->arr, 3, 4);
 
-for my $lrTest (@testcases) {
+for my $lrTest (@{$testcases->arr}) {
 	my ($where, $opts, $testin, $out_re, $err_re) = @$lrTest;
 
 	my ($out, $err);

--- a/t/03-cmdline.t
+++ b/t/03-cmdline.t
@@ -13,17 +13,20 @@ my @testcases=(
 	['--version','',qr/\bversion\b/],
 
 	# Debug output
-	['-d','',qr/^package PPP_;/m],
+	['-d','',qr/^package PPP_[0-9]*;/m],
 	['-d', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}],
 	['--debug', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}],
 	['-E', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}],
 
 	# Usage
-	['-h', '', qr/^Usage/],
-	['--help', '', qr/^Usage/],
+	['-h --z_noexit_on_help', '', qr/^Usage/],
+	['--help --z_noexit_on_help', '', qr/^Usage/],
 
 	# Eval at start of file
-	['-e \'my $foo=42;\'','<?= $foo ?>', qr/^42$/],
+	[['-e', 'my $foo=42;'],'<?= $foo ?>', qr/^42$/],
+	# TODO RESUME HERE: break down the command line arguments since the
+	# shell is no longer parsing them.  (Note that they will have to be
+	# re-quoted for use by the packed test.)
 	['--eval \'my $foo=42;\'','<?= $foo ?>', qr/^42$/],
 	['-d -e \'my $foo=42;\'','<?= $foo ?>', qr/^my \$foo=42;/m],
 	['--debug --eval \'my $foo=42;\'','<?= $foo ?>', qr/^print\s+\$foo\s*;/m],
@@ -115,16 +118,16 @@ for my $lrTest (@testcases) {
 	my ($opts, $testin, $out_re, $err_re) = @$lrTest;
 
 	my ($out, $err);
-	diag "$opts", " <<<'", $testin, "'\n";
+	diag $opts, " <<<'", $testin, "'\n";
 	run_perlpp $opts, \$testin, \$out, \$err;
-	diag "Done running";
+	#diag "Done running";
 
 	if(defined $out_re) {
-		diag "checking output";
+		#diag "checking output";
 		like($out, $out_re);
 	}
 	if(defined $err_re) {
-		diag "checking stderr";
+		#diag "checking stderr";
 		like($err, $err_re);
 	}
 	print STDERR "$err\n";

--- a/t/03-cmdline.t
+++ b/t/03-cmdline.t
@@ -1,103 +1,109 @@
-#!/usr/bin/env perl -W
+#!/usr/bin/env perl
 # Tests of perlpp command-line options
 use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 use rlib './lib';
 use PerlPPTest;
 
+# Note: for all the L() calls, without a do{} around them, the line number
+# from caller() is the line number where `my @testcases` occurs.
+# TODO find out if there's a better way than do{L()}.  Maybe an L that
+# takes a block that returns a list?  That might or might not work ---
+# syntactically,
+# 	perl -MData::Dumper -E 'sub L :prototype(&) { my $func=shift; my @x = &$func(); say Dumper(\@x); }; L{1,2}'
+# does work, but I don't know if it would have the right caller.
+
 my @testcases=(
-	# [$cmdline_options, $in (the script), $out_re (expected output),
+	# [scalar filename/lineno (added by L()),
+	# 	$cmdline_options, $in (the script), $out_re (expected output),
 	#	$err_re (stderr output, if any)]
 
 	# version
-	['-v','',qr/\bversion\b/],
-	['--version','',qr/\bversion\b/],
+	do{L('-v','',qr/\bversion\b/) },
+	do{L('--version','',qr/\bversion\b/)},
 
 	# Debug output
-	['-d','',qr/^package PPP_[0-9]*;/m],
-	['-d', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}],
-	['--debug', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}],
-	['-E', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}],
+	L('-d','',qr/^package PPP_[0-9]*;/m),
+	L('-d', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}),
+	L('--debug', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}),
+	L('-E', '<?= 2+2 ?>', qr{print\s+2\+2\s*;}),
 
 	# Usage
-	['-h --z_noexit_on_help', '', qr/^Usage/],
-	['--help --z_noexit_on_help', '', qr/^Usage/],
+	L('-h --z_noexit_on_help', '', qr/^Usage/),
+	L('--help --z_noexit_on_help', '', qr/^Usage/),
 
 	# Eval at start of file
-	[['-e', 'my $foo=42;'],'<?= $foo ?>', qr/^42$/],
-	# TODO RESUME HERE: break down the command line arguments since the
-	# shell is no longer parsing them.  (Note that they will have to be
-	# re-quoted for use by the packed test.)
-	['--eval \'my $foo=42;\'','<?= $foo ?>', qr/^42$/],
-	['-d -e \'my $foo=42;\'','<?= $foo ?>', qr/^my \$foo=42;/m],
-	['--debug --eval \'my $foo=42;\'','<?= $foo ?>', qr/^print\s+\$foo\s*;/m],
+	L('-e \'my $foo=42;\'', '<?= $foo ?>', qr/^42$/),
+	L('--eval \'my $foo=42;\'','<?= $foo ?>', qr/^42$/),
+	L('-d -e \'my $foo=42;\'','<?= $foo ?>', qr/^my \$foo=42;/m),
+	L('--debug --eval \'my $foo=42;\'','<?= $foo ?>', qr/^print\s+\$foo\s*;/m),
 
 	# Definitions: name formats
-	['-Dfoo', '<? print "yes" if $D{foo}; ?>',qr/^yes$/],
-	['-Dfoo42', '<? print "yes" if $D{foo42}; ?>',qr/^yes$/],
-	['-Dfoo_42', '<? print "yes" if $D{foo_42}; ?>',qr/^yes$/],
-	['-D_x', '<? print "yes" if $D{_x}; ?>',qr/^yes$/],
-	['-D_1', '<? print "yes" if $D{_1}; ?>',qr/^yes$/],
+	L('-Dfoo', '<? print "yes" if $D{foo}; ?>',qr/^yes$/),
+	L('-Dfoo42', '<? print "yes" if $D{foo42}; ?>',qr/^yes$/),
+	L('-Dfoo_42', '<? print "yes" if $D{foo_42}; ?>',qr/^yes$/),
+	L('-D_x', '<? print "yes" if $D{_x}; ?>',qr/^yes$/),
+	L('-D_1', '<? print "yes" if $D{_1}; ?>',qr/^yes$/),
 
 	# Definitions with --define
-	['--define foo', '<? print "yes" if $D{foo}; ?>',qr/^yes$/],
-	['--define foo=42 --define bar=127', '<?= $D{foo} * $D{bar} ?>',qr/^5334$/],
+	L('--define foo', '<? print "yes" if $D{foo}; ?>',qr/^yes$/),
+	L('--define foo=42 --define bar=127', '<?= $D{foo} * $D{bar} ?>',qr/^5334$/),
 
 	# Definitions: :define/:undef
-	['','<?:define foo?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^yes$/],
-	['','<?:define foo 42?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^yes$/],
-	['','<?:define foo 42?><?= $D{foo} ?>',qr/^42$/],
-	['','<?:define foo "a" . "b" ?><?= $D{foo} ?>',qr/^ab$/],
-	['-Dfoo','<?:undef foo?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^no$/],
+	L('','<?:define foo?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^yes$/),
+	L('','<?:define foo 42?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^yes$/),
+	L('','<?:define foo 42?><?= $D{foo} ?>',qr/^42$/),
+	L('','<?:define foo "a" . "b" ?><?= $D{foo} ?>',qr/^ab$/),
+	L('-Dfoo','<?:undef foo?><?:ifdef foo?>yes<?:else?>no<?:endif?>',qr/^no$/),
 
 	# Definitions: values
-	['-Dfoo=41025.5', '<?= $D{foo} ?>',qr/^41025.5$/],
-	['-D foo=2017', '<?= $D{foo} ?>',qr/^2017$/],
-	['-D foo=\"blah\"', '<?= $D{foo} ?>',qr/^blah$/],
+	L('-Dfoo=41025.5', '<?= $D{foo} ?>',qr/^41025.5$/),
+	L('-D foo=2017', '<?= $D{foo} ?>',qr/^2017$/),
+	L('-D foo=\"blah\"', '<?= $D{foo} ?>',qr/^blah$/),
 		# Have to escape the double-quotes so perl sees it as a string
 		# literal instead of a bareword.
-	['-D foo=42 -D bar=127', '<?= $D{foo} * $D{bar} ?>',qr/^5334$/],
-	['', '<? $D{x}="%D always exists even if empty"; ?><?= $D{x} ?>',
-		qr/^%D always exists even if empty$/],
+	L('-D foo=42 -D bar=127', '<?= $D{foo} * $D{bar} ?>',qr/^5334$/),
+	L('', '<? $D{x}="%D always exists even if empty"; ?><?= $D{x} ?>',
+		qr/^%D always exists even if empty$/),
 
 	# Textual substitution
-	['-Dfoo=42','<? my $foo; ?>foo',qr/^42$/ ],
-	['-Dfoo=\'"a phrase"\'','<? my $foo; ?>foo',qr/^a phrase$/ ],
-	['-Dfoo=\"bar\"','_foo foo foobar barfoo',qr/^_foo bar foobar barfoo$/ ],
-	['-Dfoo=\"bar\" --define barfoo','_foo foo foobar barfoo',
-		qr/^_foo bar foobar barfoo$/ ],
+	L('-Dfoo=42','<? my $foo; ?>foo',qr/^42$/ ),
+	L('-Dfoo=\'"a phrase"\'','<? my $foo; ?>foo',qr/^a phrase$/ ),
+	L('-Dfoo=\"bar\"','_foo foo foobar barfoo',qr/^_foo bar foobar barfoo$/ ),
+	L('-Dfoo=\"bar\" --define barfoo','_foo foo foobar barfoo',
+		qr/^_foo bar foobar barfoo$/ ),
 
 	# Sets, which do not textually substitute
-	['-sfoo=42','<? my $foo; ?>foo',qr/^foo$/ ],
-	['-sfoo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ ],
-	['--set foo=42','<? my $foo; ?>foo',qr/^foo$/ ],
-	['--set foo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ ],
+	do{L('-E -sfoo=42','<? my $foo; ?>foo',qr/^foo$/ )},
+	do{L('-sfoo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ )},
+	[__LINE__, '--set foo=42','<? my $foo; ?>foo',qr/^foo$/ ],
+	do{L('--set foo=42','<? my $foo; ?><?= $S{foo} ?>',qr/^42$/ )},
 
 	# Conditionals
-	['-Dfoo=42','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ ],
-	['-Dfoo=2','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^yes$/ ],
-	['-Dfoo','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ ],
-	['-Dfoo','<?:if foo==1?>yes<?:else?>no<?:endif?>',qr/^yes$/ ],
+	L('-Dfoo=42','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
+	L('-Dfoo=2','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^yes$/ ),
+	L('-Dfoo','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
+	L('-Dfoo','<?:if foo==1?>yes<?:else?>no<?:endif?>',qr/^yes$/ ),
 		# The default value is true, which compares equal to 1.
-	['-Dfoo','<?:if foo?>yes<?:else?>no<?:endif?>',qr/^yes$/ ],
-	['','<?:if foo?>yes<?:else?>no<?:endif?>',qr/^no$/ ],
-	['','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ ],
+	L('-Dfoo','<?:if foo?>yes<?:else?>no<?:endif?>',qr/^yes$/ ),
+	L('','<?:if foo?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
+	L('','<?:if foo==2?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
 		# For consistency, all :if tests evaluate to false if the
 		# named variable is not defined.
 
 	# Undefining
-	['-Dfoo','<?:undef foo?><?:if foo?>yes<?:else?>no<?:endif?>',qr/^no$/ ],
-
+	L('-Dfoo','<?:undef foo?><?:if foo?>yes<?:else?>no<?:endif?>',qr/^no$/ ),
+	#
 	# Three forms of elsif
-	['', '<?:if foo eq "1" ?>yes<?:elif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/],
-	['', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/],
-	['', '<?:if foo eq "1" ?>yes<?:elseif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/],
+	L('', '<?:if foo eq "1" ?>yes<?:elif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/),
+	L('', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/),
+	L('', '<?:if foo eq "1" ?>yes<?:elseif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/),
 
 	# elsif with definitions
-	['-Dfoo', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^yes$/],
-	['-Dfoo=1', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^yes$/],
+	L('-Dfoo', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^yes$/),
+	L('-Dfoo=1', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^yes$/),
 		# Automatic conversion of numeric 1 to string in "eq" context
-	['-Dfoo=\\"x\\"', '<?= $D{foo} . "\n" ?><?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^x\nmaybe$/],
-	['-Dfoo=\\"y\\"', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/],
+	L('-Dfoo=\\"x\\"', '<?= $D{foo} . "\n" ?><?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^x\nmaybe$/),
+	L('-Dfoo=\\"y\\"', '<?:if foo eq "1" ?>yes<?:elsif foo eq "x" ?>maybe<?:else?>no<?:endif?>', qr/^no$/),
 
 ); #@testcases
 
@@ -106,7 +112,7 @@ my @testcases=(
 my $testcount = 0;
 
 for my $lrTest (@testcases) {
-	my ($out_re, $err_re) = @$lrTest[2..3];
+	my ($out_re, $err_re) = @$lrTest[3..4];
 	++$testcount if defined $out_re;
 	++$testcount if defined $err_re;
 }
@@ -115,20 +121,21 @@ plan tests => $testcount;
 diag "Running $testcount tests";
 
 for my $lrTest (@testcases) {
-	my ($opts, $testin, $out_re, $err_re) = @$lrTest;
+	my ($where, $opts, $testin, $out_re, $err_re) = @$lrTest;
 
 	my ($out, $err);
+	diag '=' x 70;
 	diag $opts, " <<<'", $testin, "'\n";
 	run_perlpp $opts, \$testin, \$out, \$err;
 	#diag "Done running";
 
 	if(defined $out_re) {
 		#diag "checking output";
-		like($out, $out_re);
+		like($out, $out_re, "stdout $where");
 	}
 	if(defined $err_re) {
 		#diag "checking stderr";
-		like($err, $err_re);
+		like($err, $err_re, "stderr $where");
 	}
 	print STDERR "$err\n";
 

--- a/t/03-cmdline.t
+++ b/t/03-cmdline.t
@@ -1,10 +1,8 @@
 #!/usr/bin/env perl -W
 # Tests of perlpp command-line options
-use strict;
-use warnings;
-use Test::More;
-use IPC::Run3;
 use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
+use rlib './lib';
+use PerlPPTest;
 
 my @testcases=(
 	# [$cmdline_options, $in (the script), $out_re (expected output),
@@ -111,21 +109,25 @@ for my $lrTest (@testcases) {
 }
 
 plan tests => $testcount;
+diag "Running $testcount tests";
 
 for my $lrTest (@testcases) {
 	my ($opts, $testin, $out_re, $err_re) = @$lrTest;
 
 	my ($out, $err);
-	#print STDERR CMD . " $opts", " <<<'", $testin, "'\n";
-	run3 CMD . " $opts", \$testin, \$out, \$err;
+	diag "$opts", " <<<'", $testin, "'\n";
+	run_perlpp $opts, \$testin, \$out, \$err;
+	diag "Done running";
 
 	if(defined $out_re) {
+		diag "checking output";
 		like($out, $out_re);
 	}
 	if(defined $err_re) {
+		diag "checking stderr";
 		like($err, $err_re);
 	}
-	#print STDERR "$err\n";
+	print STDERR "$err\n";
 
 } # foreach test
 

--- a/t/03-cmdline.t
+++ b/t/03-cmdline.t
@@ -107,18 +107,7 @@ my @testcases=(
 
 ); #@testcases
 
-# count the out_re and err_re in @testcases, since the number of
-# tests is the sum of those counts.
-my $testcount = 0;
-
-for my $lrTest (@testcases) {
-	my ($out_re, $err_re) = @$lrTest[3..4];
-	++$testcount if defined $out_re;
-	++$testcount if defined $err_re;
-}
-
-plan tests => $testcount;
-diag "Running $testcount tests";
+plan tests => count_tests(\@testcases, 3, 4);
 
 for my $lrTest (@testcases) {
 	my ($where, $opts, $testin, $out_re, $err_re) = @$lrTest;

--- a/t/03-idempotency.t
+++ b/t/03-idempotency.t
@@ -3,20 +3,31 @@
 # Always uses the Text/PerlPP.pm in lib, for simplicity.
 use rlib './lib';
 use PerlPPTest;
-use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp')
-	. ' lib/Text/PerlPP.pm';
-diag 'idempotency-test command: ' . CMD;
+#use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp')
+#. ' lib/Text/PerlPP.pm';
+#diag 'idempotency-test command: ' . CMD;
+
+plan tests => 1;
+my $fn = $INC{'Text/PerlPP.pm'};
 
 my ($wholefile, $out);
 
-$wholefile = do {
+$wholefile = eval {
 	my $fh;
-	open($fh, '<', 'lib/Text/PerlPP.pm') or die("Couldn't open");
+	open($fh, '<', $fn) or die("Couldn't open $fn: $!");
 	local $/;
 	<$fh>;
 };
-
-run3 CMD, undef, \$out;
-is($out, $wholefile);
+my $loaderr = $@;
+my $err;
+if($loaderr) {
+	chomp $loaderr;
+	fail("idempotency ($loaderr)");
+} else {
+	run_perlpp [$fn], undef, \$out, \$err;
+	is($out, $wholefile, 'leaves its own source unchanged');
+	diag(substr($out,0,100));
+	diag(substr($err,0,100));
+}
 
 # vi: set ts=4 sts=0 sw=4 noet ai: #

--- a/t/03-idempotency.t
+++ b/t/03-idempotency.t
@@ -1,11 +1,8 @@
 #!/usr/bin/env perl -W
 # Test running perlpp on itself - nothing should change.
 # Always uses the Text/PerlPP.pm in lib, for simplicity.
-use strict;
-use warnings;
-use Test::More tests => 1;
-use IPC::Run3;
-
+use rlib './lib';
+use PerlPPTest;
 use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp')
 	. ' lib/Text/PerlPP.pm';
 diag 'idempotency-test command: ' . CMD;

--- a/t/03-idempotency.t
+++ b/t/03-idempotency.t
@@ -5,8 +5,8 @@ use PerlPPTest;
 use Text::WordDiff;
 use File::Spec;
 use Data::Dumper;
-
 plan tests => 1;
+
 my $fn = File::Spec->rel2abs($INC{'Text/PerlPP.pm'});
 
 my $wholefile;

--- a/t/03-idempotency.t
+++ b/t/03-idempotency.t
@@ -1,16 +1,15 @@
-#!/usr/bin/env perl -W
+#!/usr/bin/env perl
 # Test running perlpp on itself - nothing should change.
-# Always uses the Text/PerlPP.pm in lib, for simplicity.
 use rlib './lib';
 use PerlPPTest;
-#use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp')
-#. ' lib/Text/PerlPP.pm';
-#diag 'idempotency-test command: ' . CMD;
+use Text::WordDiff;
+use File::Spec;
+use Data::Dumper;
 
 plan tests => 1;
-my $fn = $INC{'Text/PerlPP.pm'};
+my $fn = File::Spec->rel2abs($INC{'Text/PerlPP.pm'});
 
-my ($wholefile, $out);
+my $wholefile;
 
 $wholefile = eval {
 	my $fh;
@@ -19,15 +18,25 @@ $wholefile = eval {
 	<$fh>;
 };
 my $loaderr = $@;
-my $err;
+my $out;
+
 if($loaderr) {
 	chomp $loaderr;
 	fail("idempotency ($loaderr)");
 } else {
-	run_perlpp [$fn], undef, \$out, \$err;
-	is($out, $wholefile, 'leaves its own source unchanged');
-	diag(substr($out,0,100));
-	diag(substr($err,0,100));
+	my $lrArgs = [$fn];
+	unshift @$lrArgs, '-E' if @ARGV;
+		# debugging help for running this test from the command line
+
+	diag "Checking $fn";
+	#diag "args: ", Dumper(\@ARGV);
+	run_perlpp $lrArgs, undef, \$out;
+
+	ok($out eq $wholefile, 'leaves its own source unchanged');
+	diag "Diff:\n" . word_diff \$wholefile, \$out unless $out eq $wholefile;
+
+	#diag("Out:\n" . (@ARGV ? $out : substr($out,0,100)));
+	#diag("Wholefile:\n" . $wholefile) if @ARGV;
 }
 
 # vi: set ts=4 sts=0 sw=4 noet ai: #

--- a/t/03-idempotency.t
+++ b/t/03-idempotency.t
@@ -2,7 +2,7 @@
 # Test running perlpp on itself - nothing should change.
 use rlib './lib';
 use PerlPPTest;
-use Text::WordDiff;
+use Text::Diff;
 use File::Spec;
 use Data::Dumper;
 plan tests => 1;
@@ -33,7 +33,7 @@ if($loaderr) {
 	run_perlpp $lrArgs, undef, \$out;
 
 	ok($out eq $wholefile, 'leaves its own source unchanged');
-	diag "Diff:\n" . word_diff \$wholefile, \$out unless $out eq $wholefile;
+	diag("Diff:\n" . diff \$wholefile, \$out) unless $out eq $wholefile;
 
 	#diag("Out:\n" . (@ARGV ? $out : substr($out,0,100)));
 	#diag("Wholefile:\n" . $wholefile) if @ARGV;

--- a/t/04-include.t
+++ b/t/04-include.t
@@ -33,7 +33,7 @@ plan tests => count_tests(\@testcases, 2, 3);
 
 for my $lrTest (@testcases) {
 	my ($lineno, $testin, $refout, $referr) = @$lrTest;
-	diag "<<<@{[Text::PerlPP::_QuoteString $testin]}";
+	#diag "<<<@{[Text::PerlPP::_QuoteString $testin]}";
 	run_perlpp [], \$testin, \$out, \$err;
 
 	if(defined $refout) {

--- a/t/04-include.t
+++ b/t/04-include.t
@@ -1,9 +1,7 @@
 #!/usr/bin/env perl -W
 # Tests of :include, :macro Include, :immediate ProcessFile
-use strict;
-use warnings;
-use Test::More;
-use IPC::Run3;
+use rlib './lib';
+use PerlPPTest;
 use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 
 (my $whereami = __FILE__) =~ s/04-include\.t$//;

--- a/t/05-external-command.t
+++ b/t/05-external-command.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -W
+#!/usr/bin/env perl
 # Tests of perlpp <?!...?> external commands
 use rlib './lib';
 use PerlPPTest;
@@ -20,17 +20,7 @@ my @testcases=(
 
 ); #@testcases
 
-# count the out_re and err_re in @testcases, since the number of
-# tests is the sum of those counts.
-my $testcount = 0;
-
-for my $lrTest (@testcases) {
-	my ($out_re, $err_re) = @$lrTest[2..3];
-	++$testcount if defined $out_re;
-	++$testcount if defined $err_re;
-}
-
-plan tests => $testcount;
+plan tests => count_tests(\@testcases, 2, 3);
 
 for my $lrTest (@testcases) {
 	my ($opts, $testin, $out_re, $err_re) = @$lrTest;

--- a/t/05-external-command.t
+++ b/t/05-external-command.t
@@ -1,9 +1,7 @@
 #!/usr/bin/env perl -W
 # Tests of perlpp <?!...?> external commands
-use strict;
-use warnings;
-use Test::More;
-use IPC::Run3;
+use rlib './lib';
+use PerlPPTest;
 use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 
 (my $whereami = __FILE__) =~ s/macro\.t$//;

--- a/t/05-external-command.t
+++ b/t/05-external-command.t
@@ -28,7 +28,7 @@ for my $lrTest (@testcases) {
 	my ($opts, $testin, $out_re, $err_re) = @$lrTest;
 
 	my ($out, $err);
-	diag "perlpp $opts <<<@{[Text::PerlPP::_QuoteString $testin]}";
+	#diag "perlpp $opts <<<@{[Text::PerlPP::_QuoteString $testin]}";
 	run_perlpp $opts, \$testin, \$out, \$err;
 
 	if(defined $out_re) {

--- a/t/05-external-command.t
+++ b/t/05-external-command.t
@@ -1,8 +1,10 @@
 #!/usr/bin/env perl
 # Tests of perlpp <?!...?> external commands
+#
+# TODO: On non-Unix, test only `echo` with no parameters.
+
 use rlib './lib';
 use PerlPPTest;
-use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 
 (my $whereami = __FILE__) =~ s/macro\.t$//;
 my $incfn = '\"' . $whereami . 'included.txt\"';
@@ -26,8 +28,8 @@ for my $lrTest (@testcases) {
 	my ($opts, $testin, $out_re, $err_re) = @$lrTest;
 
 	my ($out, $err);
-	print STDERR CMD . " $opts", " <<<'", $testin, "'\n";
-	run3 CMD . " $opts", \$testin, \$out, \$err;
+	diag "perlpp $opts <<<@{[Text::PerlPP::_QuoteString $testin]}";
+	run_perlpp $opts, \$testin, \$out, \$err;
 
 	if(defined $out_re) {
 		like($out, $out_re);

--- a/t/06-macro.t
+++ b/t/06-macro.t
@@ -1,9 +1,7 @@
 #!/usr/bin/env perl -W
 # Tests of perlpp :macro and related
-use strict;
-use warnings;
-use Test::More 'no_plan';
-use IPC::Run3;
+use rlib './lib';
+use PerlPPTest;
 use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 
 (my $whereami = __FILE__) =~ s/06-macro\.t$//;

--- a/t/06-macro.t
+++ b/t/06-macro.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -W
+#!/usr/bin/env perl
 # Tests of perlpp :macro and related
 use rlib './lib';
 use PerlPPTest;
@@ -23,9 +23,7 @@ my @testcases=(
 
 ); #@testcases
 
-#plan tests => scalar @testcases;
-# TODO count the out_re and err_re in @testcases, since the number of
-# tests is the sum of those counts.
+plan tests => count_tests(\@testcases, 2, 3);
 
 for my $lrTest (@testcases) {
 	my ($opts, $testin, $out_re, $err_re) = @$lrTest;

--- a/t/06-macro.t
+++ b/t/06-macro.t
@@ -2,7 +2,6 @@
 # Tests of perlpp :macro and related
 use rlib './lib';
 use PerlPPTest;
-use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 
 (my $whereami = __FILE__) =~ s/06-macro\.t$//;
 my $incfn = '\"' . $whereami . 'included.txt\"';

--- a/t/06-macro.t
+++ b/t/06-macro.t
@@ -14,10 +14,10 @@ my @testcases=(
 	#	$err_re (stderr output, if any)]
 
 	# %Defs
-	['-D foo=42', '<?:macro say $Text::PerlPP::Defs{foo}; ?>', qr/^42/],
-	['-D incfile=' . $incfn , '<?:macro Include $Text::PerlPP::Defs{incfile}; ?>',
+	['-D foo=42', '<?:macro say $PSelf->{Defs}->{foo}; ?>', qr/^42/],
+	['-D incfile=' . $incfn , '<?:macro $PSelf->Include( $PSelf->{Defs}->{incfile} ); ?>',
 		qr/^a4b/],
-	['-s incfile=' . $incfn , '<?:macro Include $Text::PerlPP::Sets{incfile}; ?>',
+	['-s incfile=' . $incfn , '<?:macro $PSelf->Include( $PSelf->{Sets}->{incfile} ); ?>',
 		qr/^a4b/],
 	['', '<?:immediate say "print 128;"; ?>',qr/^128$/],
 
@@ -29,8 +29,8 @@ for my $lrTest (@testcases) {
 	my ($opts, $testin, $out_re, $err_re) = @$lrTest;
 
 	my ($out, $err);
-	print STDERR CMD . " $opts", " <<<'", $testin, "'\n";
-	run3 CMD . " $opts", \$testin, \$out, \$err;
+	diag "perlpp $opts", " <<<'", $testin, "'\n";
+	run_perlpp $opts, \$testin, \$out, \$err;
 
 	if(defined $out_re) {
 		like($out, $out_re);

--- a/t/07-invalid.t
+++ b/t/07-invalid.t
@@ -2,9 +2,7 @@
 # Testing perlpp with invalid input
 use rlib './lib';
 use PerlPPTest;
-#use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 (my $whereami = __FILE__) =~ s/07-invalid\.t$//;
-#diag "perlpp command " . CMD . "; whereami $whereami.";
 
 my ($out, $err);
 

--- a/t/07-invalid.t
+++ b/t/07-invalid.t
@@ -1,9 +1,7 @@
 #!/usr/bin/env perl -W
 # Testing perlpp with invalid input
-use strict;
-use warnings;
-use Test::More;
-use IPC::Run3;
+use rlib './lib';
+use PerlPPTest;
 use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 (my $whereami = __FILE__) =~ s/07-invalid\.t$//;
 diag "perlpp command " . CMD . "; whereami $whereami.";

--- a/t/07-invalid.t
+++ b/t/07-invalid.t
@@ -30,8 +30,8 @@ my @testcases2 =(
 	# please just make sure to document the change and the reason in the
 	# corresponding commit message.
 	[qr/script.*-E/, '--Elines', $whereami . 'multiline.txt'],
-	[qr/error.*line 47/, '--Elines', $whereami . 'multiline.txt'],
-	[qr/Number found.*line 48/, '--Elines', $whereami . 'multiline.txt'],
+	[qr/error.*line 48/, '--Elines', $whereami . 'multiline.txt'],
+	[qr/Number found.*line 49/, '--Elines', $whereami . 'multiline.txt'],
 );
 
 plan tests =>
@@ -51,7 +51,7 @@ for my $lrTest (@testcases) {
 
 for my $lrTest (@testcases2) {
 	my $err_re = shift @$lrTest;
-	diag join(' ',@$lrTest);
+	#diag join(' ',@$lrTest);
 	run_perlpp $lrTest, undef, undef, \$err;
 	like($err, $err_re);
 }

--- a/t/07-invalid.t
+++ b/t/07-invalid.t
@@ -1,10 +1,10 @@
-#!/usr/bin/env perl -W
+#!/usr/bin/env perl
 # Testing perlpp with invalid input
 use rlib './lib';
 use PerlPPTest;
-use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
+#use constant CMD => ($ENV{PERLPP_CMD} || 'perl -Iblib/lib blib/script/perlpp');
 (my $whereami = __FILE__) =~ s/07-invalid\.t$//;
-diag "perlpp command " . CMD . "; whereami $whereami.";
+#diag "perlpp command " . CMD . "; whereami $whereami.";
 
 my ($out, $err);
 

--- a/t/07-invalid.t
+++ b/t/07-invalid.t
@@ -44,14 +44,15 @@ for my $lrTest (@testcases) {
 		# by default, accept any stderr output as indicative of a failure
 		# (a successful test case).
 
-	run3 CMD, \$testin, \$out, \$err;
+	run_perlpp [], \$testin, \$out, \$err;
 	like($err, $err_re);
 
 } # foreach test
 
 for my $lrTest (@testcases2) {
 	my $err_re = shift @$lrTest;
-	run3 join(' ', CMD, @$lrTest), \undef, \undef, \$err;
+	diag join(' ',@$lrTest);
+	run_perlpp $lrTest, undef, undef, \$err;
 	like($err, $err_re);
 }
 

--- a/t/lib/PerlPPTest.pm
+++ b/t/lib/PerlPPTest.pm
@@ -20,9 +20,10 @@ use Config;
 use IPC::Run3;
 use Text::ParseWords qw(shellwords);
 
-# Debugging aids
-use Data::Dumper;
-use Devel::StackTrace;
+# Debugging aids.  NOTE: not in Makefile.PL since we usually don't need them.
+# Install them manually if you want to use them.
+#use Data::Dumper;
+#use Devel::StackTrace;
 
 our @EXPORT = qw(run_perlpp L count_tests);
 our @EXPORT_OK = qw(get_perl_filename);
@@ -31,8 +32,8 @@ our @EXPORT_OK = qw(get_perl_filename);
 # caller's filename:line number at the front of the list
 sub L {
 	my (undef, $filename, $line) = caller;
-	#say STDERR "\n## L trace:\n",
-	#	(Devel::StackTrace->new->as_string() =~ s/^/##/mgr);
+	#do { (my $stacktrace = Devel::StackTrace->new->as_string()) =~ s/^/##/gm;
+	#say STDERR "\n## L trace:\n$stacktrace"; }
 	return ["$filename:$line", @_];
 } #L
 
@@ -48,7 +49,8 @@ sub run_perlpp {
 	my $retval;
 
 	$lrArgs = [shellwords($lrArgs)] if ref $lrArgs ne 'ARRAY';
-	#say STDERR "## args:\n", (Dumper($lrArgs) =~ s/^/##/mgr);
+	#do { (my $args = Dumper($lrArgs)) =~ s/^/##/gm;
+	#say STDERR "## args:\n$args"; };
 
 	if($ENV{PERLPP_PERLOPTS}) {
 		#my $cmd = join(' ', get_perl_filename(), $ENV{PERLPP_PERLOPTS},

--- a/t/lib/PerlPPTest.pm
+++ b/t/lib/PerlPPTest.pm
@@ -24,7 +24,7 @@ use Text::ParseWords qw(shellwords);
 use Data::Dumper;
 use Devel::StackTrace;
 
-our @EXPORT = qw(run_perlpp L);
+our @EXPORT = qw(run_perlpp L count_tests);
 our @EXPORT_OK = qw(get_perl_filename);
 
 # L: given a list, return an array ref that includes that list, with the
@@ -92,6 +92,22 @@ sub get_perl_filename {
 	}
 	return $secure_perl_path;
 } # get_perl_filename()
+
+# Count the number of tests in an array of arrays.
+# Input:
+# 	$lrTests	arrayref, e.g., [ [test1], [test2], ... ]
+# 	@fields		which fields in each test should be counted, e.g., (2, 3).
+sub count_tests {
+	my ($lrTests, @fields) = @_;
+	my $testcount = 0;
+
+	for my $lrTest (@$lrTests) {
+		do { ++$testcount if defined $lrTest->[$_] } for @fields;
+	}
+	return $testcount;
+} # count_tests()
+
+#########################################
 
 sub import {
 	my $target = caller;

--- a/t/lib/PerlPPTest.pm
+++ b/t/lib/PerlPPTest.pm
@@ -39,6 +39,7 @@ sub L {
 # run_perlpp: Run perlpp
 # Args: $lrArgs, $refStdin, $refStdout, $refStderr
 sub run_perlpp {
+	#say STDERR "args ", Dumper(\@_);
 	my $lrArgs = shift;
 	my $refStdin = shift // \(my $nullstdin);
 	my $refStdout = shift // \(my $nullstdout);

--- a/t/lib/PerlPPTest.pm
+++ b/t/lib/PerlPPTest.pm
@@ -31,19 +31,23 @@ our @EXPORT_OK = qw(get_perl_filename);
 # caller's filename:line number at the front of the list
 sub L {
 	my (undef, $filename, $line) = caller;
-	say STDERR "\n## L trace:\n",
-		(Devel::StackTrace->new->as_string() =~ s/^/##/mgr);
+	#say STDERR "\n## L trace:\n",
+	#	(Devel::StackTrace->new->as_string() =~ s/^/##/mgr);
 	return ["$filename:$line", @_];
 } #L
 
 # run_perlpp: Run perlpp
 # Args: $lrArgs, $refStdin, $refStdout, $refStderr
 sub run_perlpp {
-	my ($lrArgs, $refStdin, $refStdout, $refStderr) = @_;
+	my $lrArgs = shift;
+	my $refStdin = shift // \(my $nullstdin);
+	my $refStdout = shift // \(my $nullstdout);
+	my $refStderr = shift // \(my $nullstderr);
+
 	my $retval;
 
 	$lrArgs = [shellwords($lrArgs)] if ref $lrArgs ne 'ARRAY';
-	say STDERR "## args:\n", (Dumper($lrArgs) =~ s/^/##/mgr);
+	#say STDERR "## args:\n", (Dumper($lrArgs) =~ s/^/##/mgr);
 
 	if($ENV{PERLPP_PERLOPTS}) {
 		#say STDERR "# running external perl";

--- a/t/lib/PerlPPTest.pm
+++ b/t/lib/PerlPPTest.pm
@@ -51,12 +51,17 @@ sub run_perlpp {
 	#say STDERR "## args:\n", (Dumper($lrArgs) =~ s/^/##/mgr);
 
 	if($ENV{PERLPP_PERLOPTS}) {
-		#say STDERR "# running external perl";
-		$retval = run3(
-			join(' ', get_perl_filename(), $ENV{PERLPP_PERLOPTS},
-				@$lrArgs),
-			$refStdin, $refStdout, $refStderr);
+		#my $cmd = join(' ', get_perl_filename(), $ENV{PERLPP_PERLOPTS},
+		#		@$lrArgs);
+		my $cmd = [get_perl_filename(), shellwords($ENV{PERLPP_PERLOPTS}),
+					@$lrArgs];
+		#say STDERR '# running external perl: {', join('|',@$cmd), '}';
+		$retval = run3($cmd, $refStdin, $refStdout, $refStderr);
+		#say STDERR "#  returned $retval; status $?";
 		# TODO figure out $?, retval, &c.
+		# TODO tell the caller if the user hit Ctl-C on the inner perl
+		# invocation so the caller can abort if desired.
+		# That seems to be status 2, on my test system.
 
 	} else {
 		#say STDERR "# running perlpp internal";

--- a/t/lib/PerlPPTest.pm
+++ b/t/lib/PerlPPTest.pm
@@ -1,0 +1,95 @@
+#!perl
+# PerlPPTest.pm: test kit for Text::PerlPP
+
+package PerlPPTest;
+
+use 5.010001;
+use feature ':5.10';
+
+use strict;
+use warnings;
+
+use parent 'Exporter';
+use Import::Into;
+
+use Test::More;
+use Text::PerlPP;
+use Capture::Tiny 'capture';
+use Carp;
+use Config;
+use IPC::Run3;
+
+use Data::Dumper;
+
+our @EXPORT = qw(run_perlpp);
+our @EXPORT_OK = qw(get_perl_filename);
+
+# run_perlpp: Run perlpp
+# Args: $lrArgs, $refStdin, $refStdout, $refStderr
+sub run_perlpp {
+	my ($lrArgs, $refStdin, $refStdout, $refStderr) = @_;
+	my $retval;
+
+	$lrArgs = [split(' ', $lrArgs)] if ref $lrArgs ne 'ARRAY';
+
+	if($ENV{PERLPP_PERLOPTS}) {
+		say STDERR "# running external perl";
+		$retval = run3(
+			join(' ', get_perl_filename(), $ENV{PERLPP_PERLOPTS},
+				@$lrArgs),
+			$refStdin, $refStdout, $refStderr);
+		# TODO figure out $?, retval, &c.
+
+	} else {
+		say STDERR "# running perlpp internal";
+		say STDERR "# redirecting stdin";
+		open local(*STDIN), '<', $refStdin or die $!;
+		say STDERR "# redirected stdin";
+
+		my @result;
+		say STDERR "# before capture";
+		eval {
+		($$refStdout, $$refStderr, @result) = capture {
+			# Thanks to http://www.perlmonks.org/bare/?node_id=289391 by Zaxo
+			say STDERR "# running perlpp";
+			my $result = Text::PerlPP::Main($lrArgs);
+			say STDERR "# done running perlpp";
+			$result;
+		};
+		} or die "Capture failed: " . $@;
+		say STDERR "# after capture";
+		close STDIN;
+		$retval = $result[0] if @result;
+	}
+
+	return $retval;
+} #run_perlpp
+
+# Get the filename of the Perl interpreter running this.  From perlvar.
+sub get_perl_filename {
+	my $secure_perl_path = $Config{perlpath};
+	if ($^O ne 'VMS') {
+		$secure_perl_path .= $Config{_exe}
+			unless $secure_perl_path =~ m/$Config{_exe}$/i;
+	}
+	return $secure_perl_path;
+} # get_perl_filename()
+
+sub import {
+	my $target = caller;
+
+	# Copy symbols listed in @EXPORT first, in case @_ gets trashed later.
+	PerlPPTest->export_to_level(1, @_);
+
+	# Re-export packages
+	feature->import::into($target, ':5.10');
+	Capture::Tiny->import::into($target, qw(capture capture_stdout));
+	Carp->import::into($target, qw(carp croak confess));
+
+	foreach my $package (qw(strict warnings Test::More Text::PerlPP)) {
+		$package->import::into($target);
+	};
+} #import
+
+1;
+# vi: set ts=4 sts=0 sw=4 noet ai fdm=marker fdl=1: #

--- a/t/lib/PerlPPTest.pm
+++ b/t/lib/PerlPPTest.pm
@@ -65,7 +65,7 @@ sub run_perlpp {
 			($$refStdout, $$refStderr, @result) = capture {
 				# Thanks to http://www.perlmonks.org/bare/?node_id=289391 by Zaxo
 				#say STDERR "# running perlpp";
-				my $result = Text::PerlPP::Main($lrArgs);
+				my $result = Text::PerlPP->new->Main($lrArgs);
 				#say STDERR "# done running perlpp";
 				$result;
 			};

--- a/t/lib/PerlPPTest.pm
+++ b/t/lib/PerlPPTest.pm
@@ -31,6 +31,7 @@ sub run_perlpp {
 	my $retval;
 
 	$lrArgs = [split(' ', $lrArgs)] if ref $lrArgs ne 'ARRAY';
+	say STDERR "args: ", Dumper($lrArgs);
 
 	if($ENV{PERLPP_PERLOPTS}) {
 		say STDERR "# running external perl";
@@ -41,23 +42,23 @@ sub run_perlpp {
 		# TODO figure out $?, retval, &c.
 
 	} else {
-		say STDERR "# running perlpp internal";
-		say STDERR "# redirecting stdin";
+		#say STDERR "# running perlpp internal";
+		#say STDERR "# redirecting stdin";
 		open local(*STDIN), '<', $refStdin or die $!;
-		say STDERR "# redirected stdin";
+		#say STDERR "# redirected stdin";
 
 		my @result;
-		say STDERR "# before capture";
+		#say STDERR "# before capture";
 		eval {
-		($$refStdout, $$refStderr, @result) = capture {
-			# Thanks to http://www.perlmonks.org/bare/?node_id=289391 by Zaxo
-			say STDERR "# running perlpp";
-			my $result = Text::PerlPP::Main($lrArgs);
-			say STDERR "# done running perlpp";
-			$result;
-		};
+			($$refStdout, $$refStderr, @result) = capture {
+				# Thanks to http://www.perlmonks.org/bare/?node_id=289391 by Zaxo
+				say STDERR "# running perlpp";
+				my $result = Text::PerlPP::Main($lrArgs);
+				say STDERR "# done running perlpp";
+				$result;
+			};
 		} or die "Capture failed: " . $@;
-		say STDERR "# after capture";
+		#say STDERR "# after capture";
 		close STDIN;
 		$retval = $result[0] if @result;
 	}

--- a/t/lib/TestcaseList.pm
+++ b/t/lib/TestcaseList.pm
@@ -1,0 +1,48 @@
+#!perl
+# TestcaseList.pm: Automatically number a list, e.g., of testcases.
+# Copyright (c) 2018 Chris White.
+# Dual-licensed Artistic 2 or CC-BY 4.0 Intl.
+# Modified from https://stackoverflow.com/a/50516105/2877364 by
+# https://stackoverflow.com/users/2877364/cxw
+
+package TestcaseList;
+use 5.010001;
+use strict;
+use warnings;
+
+# Constructor
+sub new {   # call as $class->new(__LINE__); each element is one line
+	my $class = shift;
+	my $self = bless {lnum => shift // 0, arr => []}, $class;
+
+	# Make a loader that adds an item and returns itself --- not $self
+	$self->{loader} = sub { $self->L(@_); return $self->{loader} };
+		# TODO add a skip() method callable on the loader
+
+	return $self;
+}
+
+# Accessors
+sub size { return scalar @{ shift->{arr} }; }
+sub last { return shift->size-1; }      # $#
+sub arr { return shift->{arr}; }
+
+# Loading
+sub load { goto &{ shift->{loader} } }  # kick off loading
+
+sub L {     # Push a new record with the next line number on the front
+	my $self = shift;
+	push @{ $self->{arr} }, [++$self->{lnum}, @_];
+	return $self;
+} #L
+
+sub add {   # just add it
+	my $self = shift;
+	++$self->{lnum};    # keep it consistent
+	push @{ $self->{arr} }, [@_];
+	return $self;
+} #add
+
+1;
+
+# vi: set ts=4 sts=0 sw=4 noet ai: #


### PR DESCRIPTION
- Run tests using [`Capture::Tiny`](https://metacpan.org/pod/Capture::Tiny) whenever possible
- Run external `perl` processes using the same `perl` we're running under, not the system `perl` (thanks to SREZIC for reporting)
- Change from dotted-decimal to Perl-form version numbers, but still under semver rules.
- Update dependencies
- Add a test kit (in `t/lib`)

Fixes #24.