### PR TITLE
harden error test for perl 5.38 stop on syntax error patch

### DIFF
--- a/t/07-invalid.t
+++ b/t/07-invalid.t
@@ -21,7 +21,7 @@ my @testcases2 =(
 	# [error RE, perlpp options...]
 	[qr/multiline\.txt/, $whereami . 'multiline.txt'],
 	[qr/error.*line 12/, $whereami . 'multiline.txt'],
-	[qr/Number found.*line 13/, $whereami . 'multiline.txt'],
+	[qr/syntax error.*line 12/, $whereami . 'multiline.txt'],
 
 	# Tests with --Elines.  Note: the specific line numbers here may need
 	# to be changed if the internals of perlpp change.  This is OK;
@@ -29,7 +29,7 @@ my @testcases2 =(
 	# corresponding commit message.
 	[qr/script.*-E/, '--Elines', $whereami . 'multiline.txt'],
 	[qr/error.*line 48/, '--Elines', $whereami . 'multiline.txt'],
-	[qr/Number found.*line 49/, '--Elines', $whereami . 'multiline.txt'],
+	[qr/syntax error.*line 48/, '--Elines', $whereami . 'multiline.txt'],
 );
 
 plan tests =>


### PR DESCRIPTION
We will change error behavior in perl 5.38 so that we stop compiling on the first syntax error we encounter, which breaks your module. This PR will harden your code and should pass on 5.38 or earlier perls. 

See https://github.com/Perl/perl5/issues/20346